### PR TITLE
Fix favicon in Chrome

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,7 +22,8 @@
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
-  <link rel="shortcut icon apple-touch-icon-precomposed apple-touch-icon" sizes="144x144" href="{{ site.baseurl }}/public/favicon.png">
+  <link rel="shortcut icon" sizes="144x144" type="image/png" href="{{ site.baseurl }}/public/favicon.png">
+  <link rel="apple-touch-icon-precomposed apple-touch-icon" sizes="144x144" type="image/png" href="{{ site.baseurl }}/public/favicon.png">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}/atom.xml">


### PR DESCRIPTION
Chrome did not display the favicon of the page. Chrome only seems to show an icon if the tag `<link rel="shortcut icon" href="..." ...>` has no additional values in the `rel` attribute. I have updated _includes/head.html accordingly.  
