### PR TITLE
Updated GAP Demo notebook path

### DIFF
--- a/_data/try.yml
+++ b/_data/try.yml
@@ -5,7 +5,7 @@
 
 - name: Try GAP
   repo: gap-system/try-gap-in-jupyter
-  file: notebooks/NewNotebook.ipynb
+  file: NewNotebook.ipynb
   thumbnail: /try/thumbnails/GAPLogo.png
 
 - name: Try PARI/GP


### PR DESCRIPTION
Once https://github.com/gap-system/try-gap-in-jupyter/pull/4 is merged, this fixes the notebook paths